### PR TITLE
Fixed addback zero degree hits

### DIFF
--- a/Converter.cc
+++ b/Converter.cc
@@ -941,7 +941,7 @@ bool Converter::Run() {
                                     }
                                 }
                             }
-                            angle = GriffinCryMap[(int)((4*fGriffinDetector->at(firstDet).DetectorId())+cry1)][(int)((4*fGriffinDetector->at(firstDet).DetectorId())+cry2)];
+                            angle = 0;
                             for(int i = 0; i < 52; i++) {
                                 if(GriffinCryMapCombos[i][0] == angle) {
                                     norm = (double)GriffinCryMapCombos[i][1];


### PR DESCRIPTION
Zero degree hits were registering as all possible angles in a detector (i.e. 19, 27) when they should all be zero. This was causing them to be placed in the incorrect bins in the 3D histogram making and hence causing issues in the angular correlations. Should be fixed now just have to be careful with normalizations.
